### PR TITLE
Extended the apiloader

### DIFF
--- a/pymacaron/apiloader.py
+++ b/pymacaron/apiloader.py
@@ -341,10 +341,14 @@ def generate_endpoints_v2(swagger, app_file, model_file, api_name):
                 for name, param in query_params.items():
                     _type, value = param
                     python_type = swagger_type_to_pydantic_type(_type)
-                    if value == None or value == "":
+                    if value == None:
                         query_model_lines.append(f'            {name}: Optional[{python_type}] = None')
                     else:
-                        query_model_lines.append(f'            {name}: {python_type} = {value}')
+                        # Careful with strings, They need to be wrapped in double quotes:
+                        if python_type == "str":
+                            query_model_lines.append(f'            {name}: {python_type} = "{value}"')
+                        else:
+                            query_model_lines.append(f'            {name}: {python_type} = {value}')
 
             # If there are path parameters, pass them as a dictionary to the
             # generic pymacaron endpoint


### PR DESCRIPTION
# Description:
I extended the functionality of the apiloader to accept default parameters in the query parameters defined in the yaml file:

## Issue
To this day, whenever you wanted to have default values assigned you needed to do the following:
```yaml
parameters:
  - in: query
    name: page
    type: integer
    description: Number of the result page to fetch (default to 0)
    required: false
```
And then extend the functionality functions to the point where they looked redundant:

```python3
def get_activities(
        page: int = 0,
        limit: int = 10,
        search: str = "",
    ) -> apipool.explore.v1ActivityPage:

    # Swagger doesn't work
    page = 0 if not page else page
    limit = 10 if not limit else limit
    search = "" if not search else search
```

* Definition in the *_app.py:
```python3
@app.route("/api/v1/activities/search", methods=["GET"])
@cross_origin(headers=["Content-Type", "Authorization"])
def endpoint_get__api_v1_activities_search():
    class QueryModel(BaseModel):
        page: Optional[int] = None
        limit: Optional[int] = None
```

## Fix:

Now, if you define **default** in the yaml file, you can remove that functionality, and let the args of the function be ilustrative:
```yaml
parameters:
  - in: query
    name: page
    type: integer
    description: Number of the result page to fetch (default to 0)
    required: false
    default: 0
```

The *_app.py file will now look as follows:
```python3
@app.route("/api/v1/groups/search", methods=["GET"])
@cross_origin(headers=["Content-Type", "Authorization"])
def endpoint_get__api_v1_groups_search():
    class QueryModel(BaseModel):
        page: int = 0
        limit: int = 10
        search: str = ""
```
And the definition of the None types in get_activities becomes unnecesary, resulting in cleaner code.

## IMPORTANT:
It **will not break already defined apis** if the pull request is accepted, if no default value is defined in the query params, it keeps the same structure as before.